### PR TITLE
Correct spelling of library.properties' depends field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Filemaker 17 DATA API Client (ESP32), Supports login, logout and creat
 category=Communication
 url=https://github.com/bmts/FMDataClient
 architectures=esp32
-dependes=ArduinoJson
+depends=ArduinoJson


### PR DESCRIPTION
dependes -> depends